### PR TITLE
Fix piping on ubuntu/debian

### DIFF
--- a/makefile
+++ b/makefile
@@ -119,12 +119,12 @@ deploy: $(LOCAL_INV) $(REMOTE_INV) ## Deploy this project with ansible
 
 # run composer
 $(PHP_DEPS): composer.json
-	composer install &> /dev/null
+	composer install > /dev/null 2>&1
 	@echo "composer install successful"
 
 # run npm
 $(JS_DEPS): package.json
-	npm install &> /dev/null
+	npm install > /dev/null 2>&1
 	@echo "npm install successful"
 
 # create the directory needed


### PR DESCRIPTION
`make` executes commands with the system shell `/bin/sh` which on Ubuntu
defaults to POSIX `dash`. When redirecting for dash `&` puts preceding
command into background. Let's redirect correctly so POSIX shell is happy.

See <https://wiki.ubuntu.com/DashAsBinSh> for more information