### PR TITLE
Update tailwind to version 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1814,13 +1814,63 @@
             "dev": true
         },
         "@fullhuman/postcss-purgecss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",
-            "integrity": "sha512-qnKm5dIOyPGJ70kPZ5jiz0I9foVOic0j+cOzNDoo8KoCf6HjicIZ99UfO2OmE7vCYSKAAepEwJtNzpiiZAh9xw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.0.0.tgz",
+            "integrity": "sha512-cvuOgMwIVlfgWcUMqg5p33NbGUxLwMrKtDKkm3QRfOo4PRVNR6+y/xd9OyXTVZiB1bIpKNJ0ZObYPWD3DRQDtw==",
             "dev": true,
             "requires": {
                 "postcss": "7.0.32",
-                "purgecss": "^2.3.0"
+                "purgecss": "^3.0.0"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "postcss": {
+                    "version": "7.0.32",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+                    "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
             }
         },
         "@nodelib/fs.scandir": {
@@ -2538,6 +2588,12 @@
             "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
             "dev": true
         },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true
+        },
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -2560,9 +2616,9 @@
             },
             "dependencies": {
                 "caniuse-lite": {
-                    "version": "1.0.30001109",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz",
-                    "integrity": "sha512-4JIXRodHzdS3HdK8nSgIqXYLExOvG+D2/EenSvcub2Kp3QEADjo2v2oUn5g0n0D+UNwG9BtwKOyGcSq2qvQXvQ==",
+                    "version": "1.0.30001159",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
+                    "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==",
                     "dev": true
                 }
             }
@@ -4249,6 +4305,12 @@
                 "defined": "^1.0.0",
                 "minimist": "^1.1.1"
             }
+        },
+        "didyoumean": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.1.tgz",
+            "integrity": "sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=",
+            "dev": true
         },
         "diffie-hellman": {
             "version": "5.0.3",
@@ -6130,6 +6192,15 @@
                 "rgba-regex": "^1.0.0"
             }
         },
+        "is-core-module": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+            "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
         "is-data-descriptor": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -6963,6 +7034,12 @@
                 "minimist": "^1.2.5"
             }
         },
+        "modern-normalize": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.0.0.tgz",
+            "integrity": "sha512-1lM+BMLGuDfsdwf3rsgBSrxJwAZHFIrQ8YR61xIqdHo0uNKI9M52wNpHSrliZATJp51On6JD0AfRxd4YGSU0lw==",
+            "dev": true
+        },
         "move-concurrently": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -7198,12 +7275,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
             "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
-            "dev": true
-        },
-        "normalize.css": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-            "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
             "dev": true
         },
         "npm-run-path": {
@@ -7795,9 +7866,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "7.0.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-            "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+            "version": "7.0.35",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+            "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2",
@@ -9083,22 +9154,70 @@
             "dev": true
         },
         "purgecss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.3.0.tgz",
-            "integrity": "sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.0.0.tgz",
+            "integrity": "sha512-t3FGCwyX9XWV3ffvnAXTw6Y3Z9kNlcgm14VImNK66xKi5sdqxSA2I0SFYxtmZbAKuIZVckPdazw5iKL/oY/2TA==",
             "dev": true,
             "requires": {
-                "commander": "^5.0.0",
+                "commander": "^6.0.0",
                 "glob": "^7.0.0",
                 "postcss": "7.0.32",
                 "postcss-selector-parser": "^6.0.2"
             },
             "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
                 "commander": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-                    "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+                    "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
                     "dev": true
+                },
+                "postcss": {
+                    "version": "7.0.32",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+                    "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
@@ -11155,50 +11274,117 @@
             }
         },
         "tailwindcss": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.9.6.tgz",
-            "integrity": "sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==",
+            "version": "npm:@tailwindcss/postcss7-compat@2.0.1",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/postcss7-compat/-/postcss7-compat-2.0.1.tgz",
+            "integrity": "sha512-SdWGioSKNhCIuoX2gCYhfs9HhWnOf1dvIed5G2i/lbqReGA27LG5KpH4glDunHWevWAY7h/WISZblE6xDCC/UA==",
             "dev": true,
             "requires": {
-                "@fullhuman/postcss-purgecss": "^2.1.2",
-                "autoprefixer": "^9.4.5",
-                "browserslist": "^4.12.0",
+                "@fullhuman/postcss-purgecss": "^3.0.0",
+                "autoprefixer": "^9",
                 "bytes": "^3.0.0",
-                "chalk": "^3.0.0 || ^4.0.0",
-                "color": "^3.1.2",
+                "chalk": "^4.1.0",
+                "color": "^3.1.3",
                 "detective": "^5.2.0",
-                "fs-extra": "^8.0.0",
+                "didyoumean": "^1.2.1",
+                "fs-extra": "^9.0.1",
                 "html-tags": "^3.1.0",
                 "lodash": "^4.17.20",
+                "modern-normalize": "^1.0.0",
                 "node-emoji": "^1.8.1",
-                "normalize.css": "^8.0.1",
                 "object-hash": "^2.0.3",
-                "postcss": "^7.0.11",
-                "postcss-functions": "^3.0.0",
-                "postcss-js": "^2.0.0",
-                "postcss-nested": "^4.1.1",
-                "postcss-selector-parser": "^6.0.0",
+                "postcss": "^7",
+                "postcss-functions": "^3",
+                "postcss-js": "^2",
+                "postcss-nested": "^4",
+                "postcss-selector-parser": "^6.0.4",
                 "postcss-value-parser": "^4.1.0",
                 "pretty-hrtime": "^1.0.3",
                 "reduce-css-calc": "^2.1.6",
-                "resolve": "^1.14.2"
+                "resolve": "^1.19.0"
             },
             "dependencies": {
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                "color": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
+                    "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
                     "dev": true,
                     "requires": {
+                        "color-convert": "^1.9.1",
+                        "color-string": "^1.5.4"
+                    }
+                },
+                "color-string": {
+                    "version": "1.5.4",
+                    "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.4.tgz",
+                    "integrity": "sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "^1.0.0",
+                        "simple-swizzle": "^0.2.2"
+                    }
+                },
+                "fs-extra": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+                    "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+                    "dev": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
                         "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^1.0.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+                    "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "universalify": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                            "dev": true
+                        }
                     }
                 },
                 "lodash": {
                     "version": "4.17.20",
                     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
                     "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+                    "dev": true
+                },
+                "postcss-selector-parser": {
+                    "version": "6.0.4",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz",
+                    "integrity": "sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1",
+                        "util-deprecate": "^1.0.2"
+                    }
+                },
+                "resolve": {
+                    "version": "1.19.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+                    "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+                    "dev": true,
+                    "requires": {
+                        "is-core-module": "^2.1.0",
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "universalify": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+                    "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
                     "dev": true
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
     "devDependencies": {
         "@symfony/webpack-encore": "^0.31.0",
+        "autoprefixer": "^9.8.6",
         "core-js": "^3.0.0",
         "cross-env": "^7.0.2",
         "fibers": "^5.0.0",
+        "postcss": "^7.0.35",
         "postcss-loader": "^3.0.0",
         "postcss-preset-env": "^6.7.0",
         "prettier": "^2.1.2",
@@ -15,7 +17,7 @@
         "stylelint-config-prettier": "^8.0.2",
         "stylelint-config-standard": "^20.0.0",
         "stylelint-scss": "^3.18.0",
-        "tailwindcss": "^1.9.6",
+        "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.1",
         "webpack-notifier": "^1.6.0"
     },
     "license": "MIT",

--- a/source/View/Assets/tailwind.config.js
+++ b/source/View/Assets/tailwind.config.js
@@ -1,5 +1,9 @@
 module.exports = {
-  purge: ["./source/View/Templates/**/*.html.twig"],
+  purge: {
+    mode: "layers",
+    layers: ["components", "utilities"],
+    content: ["./source/View/Templates/**/*.html.twig"],
+  },
   theme: {
     extend: {},
   },


### PR DESCRIPTION
This updates tailwind to version 2.0. The compatibility build is used as
webpack encore, resp. the postcss-loader version it requires currently
doesn't support postcss > 7.

Tailwind settings are adjusted to not purge components and utilities by default.